### PR TITLE
Clear role repository before seeding initial roles

### DIFF
--- a/src/main/java/com/podzilla/auth/seeder/DatabaseSeeder.java
+++ b/src/main/java/com/podzilla/auth/seeder/DatabaseSeeder.java
@@ -17,6 +17,7 @@ public class DatabaseSeeder implements CommandLineRunner {
 
     @Override
     public void run(final String... args) throws Exception {
+        roleRepository.deleteAll();
         roleRepository.save(new Role(ERole.ROLE_USER));
         roleRepository.save(new Role(ERole.ROLE_ADMIN));
         roleRepository.save(new Role(ERole.ROLE_COURIER));


### PR DESCRIPTION
This pull request updates the `DatabaseSeeder` class to ensure the database is properly reset before seeding new roles.

**Database seeding improvements:**

* [`src/main/java/com/podzilla/auth/seeder/DatabaseSeeder.java`](diffhunk://#diff-c2ce7c1f1ab67418c9ac4a5af2ae328d427b0d69d85dcedfd06f7e2da43733daR20): Added a call to `roleRepository.deleteAll()` in the `run` method to clear all existing roles before saving new ones. This ensures the database is reset during each seeding operation.