### PR TITLE
Update podzilla-utils-lib version to v1.1.13 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.github.Podzilla</groupId>
 			<artifactId>podzilla-utils-lib</artifactId>
-			<version>v1.1.6</version>
+			<version>v1.1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This pull request updates the version of a dependency in the `pom.xml` file to ensure the project uses the latest features and fixes.

Dependency update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L51-R51): Updated the `podzilla-utils-lib` dependency from version `v1.1.6` to `v1.1.13`.